### PR TITLE
[suggestion] example: Use no_std, and delay using embedded-hal

### DIFF
--- a/examples/reading_temperature.rs
+++ b/examples/reading_temperature.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 extern crate bme680;
 extern crate embedded_hal;
 extern crate env_logger;
@@ -7,10 +9,10 @@ extern crate log;
 
 use bme680::*;
 use embedded_hal::blocking::i2c;
+use embedded_hal::blocking::delay::DelayMs;
 use hal::*;
-use std::result;
-use std::thread;
-use std::time::Duration;
+use core::result;
+use core::time::Duration;
 
 fn main(
 ) -> result::Result<(), Error<<hal::I2cdev as i2c::Read>::Error, <hal::I2cdev as i2c::Write>::Error>>
@@ -20,6 +22,7 @@ fn main(
     let i2c = I2cdev::new("/dev/i2c-1").unwrap();
 
     let mut dev = Bme680::init(i2c, Delay {}, I2CAddress::Primary)?;
+    let mut delay = Delay {};
 
     let settings = SettingsBuilder::new()
         .with_humidity_oversampling(OversamplingSetting::OS2x)
@@ -41,7 +44,7 @@ fn main(
     info!("Sensor settings: {:?}", sensor_settings);
 
     loop {
-        thread::sleep(Duration::from_millis(5000));
+        delay.delay_ms(5000u32);
         let power_mode = dev.get_sensor_mode();
         info!("Sensor power mode: {:?}", power_mode);
         info!("Setting forced power modes");


### PR DESCRIPTION
This does not make any difference in the concrete example
(linux-embedded-hal's delay is implemented in terms of std::thread), but
it removes a stone from the path of people who start from the example
towards an actual use of embedded hal. (They'll still have to find
suitable replacements for env_hal and linux_embedded_hal, but that's
the parts that have to be.)

----

There are obviously many ways in which an example works. I think that this is a slight improvement, but if you disagree, feel free to just close this PR.

(The core::Duration stays in there because the lib uses Duration, and embedded-hal delays don't work with that, see https://github.com/rust-embedded/embedded-hal/issues/59).