### PR TITLE
Remove warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,8 +774,8 @@ where
     {
         let mut calib: CalibData = Default::default();
 
-        let mut coeff_array: [u8; (BME680_COEFF_ADDR1_LEN + BME680_COEFF_ADDR2_LEN)] =
-            [0; (BME680_COEFF_ADDR1_LEN + BME680_COEFF_ADDR2_LEN)];
+        let mut coeff_array: [u8; BME680_COEFF_ADDR1_LEN + BME680_COEFF_ADDR2_LEN] =
+            [0; BME680_COEFF_ADDR1_LEN + BME680_COEFF_ADDR2_LEN];
 
         I2CUtil::read_bytes::<I2CX>(
             i2c,


### PR DESCRIPTION
`unused_parens` is now on by default:

```
warning: unnecessary parentheses around const expression
   --> src\lib.rs:777:35
    |
777 |         let mut coeff_array: [u8; (BME680_COEFF_ADDR1_LEN + BME680_COEFF_ADDR2_LEN)] =
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

warning: unnecessary parentheses around const expression
   --> src\lib.rs:778:17
    |
778 |             [0; (BME680_COEFF_ADDR1_LEN + BME680_COEFF_ADDR2_LEN)];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses

warning: 2 warnings emitted
```