### PR TITLE
Pass the delayer around mutably

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ env_logger = "0.7"
 futures = { version = "0.3" }
 i2cdev = "0.4"
 influx_db_client = { version = "0.4", default-features= false, features = ["rustls-tls"] }
-linux-embedded-hal = "0.3"
 tokio = {version = "0.2", features = ["full"] }
 url = "2.1"
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+linux-embedded-hal = "0.3"

--- a/examples/reading_temperature.rs
+++ b/examples/reading_temperature.rs
@@ -15,8 +15,9 @@ fn main(
     env_logger::init();
 
     let i2c = hal::I2cdev::new("/dev/i2c-1").unwrap();
+    let mut delayer = Delay {};
 
-    let mut dev = Bme680::init(i2c, Delay {}, I2CAddress::Primary)?;
+    let mut dev = Bme680::init(i2c, &mut delayer, I2CAddress::Primary)?;
     let mut delay = Delay {};
 
     let settings = SettingsBuilder::new()
@@ -32,9 +33,9 @@ fn main(
     let profile_dur = dev.get_profile_dur(&settings.0)?;
     info!("Profile duration {:?}", profile_dur);
     info!("Setting sensor settings");
-    dev.set_sensor_settings(settings)?;
+    dev.set_sensor_settings(&mut delayer, settings)?;
     info!("Setting forced power modes");
-    dev.set_sensor_mode(PowerMode::ForcedMode)?;
+    dev.set_sensor_mode(&mut delayer, PowerMode::ForcedMode)?;
 
     let sensor_settings = dev.get_sensor_settings(settings.1);
     info!("Sensor settings: {:?}", sensor_settings);
@@ -44,9 +45,9 @@ fn main(
         let power_mode = dev.get_sensor_mode();
         info!("Sensor power mode: {:?}", power_mode);
         info!("Setting forced power modes");
-        dev.set_sensor_mode(PowerMode::ForcedMode)?;
+        dev.set_sensor_mode(&mut delayer, PowerMode::ForcedMode)?;
         info!("Retrieving sensor data");
-        let (data, _state) = dev.get_sensor_data()?;
+        let (data, _state) = dev.get_sensor_data(&mut delayer)?;
         info!("Sensor Data {:?}", data);
         info!("Temperature {}°C", data.temperature_celsius());
         info!("Pressure {}hPa", data.pressure_hpa());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 
 //! extern crate bme680;
 //! extern crate embedded_hal;
-//! extern crate linux_embedded_hal as hal;
+//! // Note that you'll have to import your board crates types corresponding to
+//! // Delay and I2cdev.
 //!
 //! use bme680::*;
 //! use embedded_hal::blocking::i2c;
@@ -15,10 +16,43 @@
 //! use std::result;
 //! use std::time::Duration;
 //!
+//! # mod hal {
+//! #   use super::*;
+//! #   use embedded_hal::blocking::delay;
+//! #
+//! #   #[derive(Debug)]
+//! #   pub struct Delay {}
+//! #
+//! #   impl delay::DelayMs<u8> for Delay {
+//! #       fn delay_ms(&mut self, _ms: u8) {}
+//! #   }
+//! #
+//! #   #[derive(Debug)]
+//! #   pub enum I2CError {}
+//! #
+//! #   pub struct I2cdev {}
+//! #
+//! #   impl i2c::Write for I2cdev {
+//! #       type Error = I2CError;
+//! #
+//! #       fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> result::Result<(), Self::Error> {
+//! #           Ok(())
+//! #       }
+//! #   }
+//! #
+//! #   impl i2c::Read for I2cdev {
+//! #       type Error = I2CError;
+//! #
+//! #       fn read<'w>(&mut self, addr: u8, bytes: &'w mut [u8]) -> result::Result<(), Self::Error> {
+//! #           Ok(())
+//! #       }
+//! #   }
+//! # }
+//!
 //! fn main() -> result::Result<(), Error<<hal::I2cdev as i2c::Read>::Error, <hal::I2cdev as i2c::Write>::Error>>
 //! {
 //!     // Initialize device
-//!     let i2c = I2cdev::new("/dev/i2c-1").unwrap();
+//!     let i2c = I2cdev {}; // Your I2C device construction will look different, perhaps using I2cdev::new(..)
 //!     let mut dev = Bme680::init(i2c, Delay {}, I2CAddress::Primary)?;
 //!     let settings = SettingsBuilder::new()
 //!         .with_humidity_oversampling(OversamplingSetting::OS2x)


### PR DESCRIPTION
This PR passes a `Delay` structure around mutably so that the `Bme680` doesn't own it and other things may then use it.

I've introduced two commits here. The first commit removes the Linux dependency to be able to build the library. This does impact the doctest for the library slightly in that I stub the required board types. The docs produced look pretty reasonable to me, but you should also give it a try.

The second commit concerns itself with the core change to pass the delayer around mutably. Note that I've not been able to successfully run the examples or thoroughly test their compilation even. Travis appears happy with their ability to compile them though. I would recommend that you test the examples and confirm their working (I'd be surprised if they didn't).

Fixes #34 