### PR TITLE
Add missing sleep to example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! use hal::*;
 //! use std::result;
 //! use std::time::Duration;
+//! use std::thread::sleep;
 //!
 //! fn main() -> result::Result<(), Error<<hal::I2cdev as i2c::Read>::Error, <hal::I2cdev as i2c::Write>::Error>>
 //! {
@@ -29,9 +30,11 @@
 //!         .with_run_gas(true)
 //!         .build();
 //!     dev.set_sensor_settings(settings)?;
+//!     let profile_duration = dev.get_profile_dur(&settings.0)?;
 //!
 //!     // Read sensor data
 //!     dev.set_sensor_mode(PowerMode::ForcedMode)?;
+//!     sleep(profile_duration);
 //!     let (data, _state) = dev.get_sensor_data()?;
 //!
 //!     println!("Temperature {}°C", data.temperature_celsius());


### PR DESCRIPTION
One has to sleep for the duration of the configured profile to read proper data.

Closes #23.