### PR TITLE
Expose gas_valid and heat_stab

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,19 @@ impl FieldData {
     pub fn gas_resistance_ohm(&self) -> u32 {
         self.gas_resistance
     }
+
+    /// Whether a real (and not a dummy) gas reading was performed.
+    pub fn gas_valid(&self) -> bool {
+        self.status & BME680_GASM_VALID_MSK != 0
+    }
+
+    /// Whether the heater target temperature for the gas reading was reached.
+    ///
+    /// If this values is `false`, the heating duration was likely too short or
+    /// the target temperature too high.
+    pub fn heat_stable(&self) -> bool {
+        self.status & BME680_HEAT_STAB_MSK != 0
+    }
 }
 
 /// Shows if new data is available


### PR DESCRIPTION
The BME680 datasheet recommends to check these values to ensure that a gas reading is valid. To do so, they must be exposed by the library.