### PR TITLE
fixes issue #42

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ const BME680_GAS_INDEX_MSK: u8 = 0x0f;
 const BME680_GAS_RANGE_MSK: u8 = 0x0f;
 const BME680_GASM_VALID_MSK: u8 = 0x20;
 const BME680_HEAT_STAB_MSK: u8 = 0x10;
+const BME680_MEASURING_MSK: u8 = 0x20;
 
 /// Buffer length macro declaration
 const BME680_TMP_BUFFER_LENGTH: usize = 40;
@@ -506,6 +507,10 @@ where
 
         for (reg_addr, reg_data) in reg {
             let tmp_buff: [u8; 2] = [*reg_addr, *reg_data];
+            while self.is_measuring()? {
+            
+            }
+    
             debug!(
                 "Setting register reg: {:?} tmp_buf: {:?}",
                 reg_addr, tmp_buff
@@ -934,6 +939,17 @@ where
         };
 
         Ok(gas_sett)
+    }
+
+    fn is_measuring(&mut self)->Result<bool, <I2C as Read>::Error, <I2C as Write>::Error>{
+        let val :u8 = 0;
+        I2CUtil::read_bytes(
+            &mut self.i2c,
+            self.dev_id.addr(),
+            BME680_FIELD0_ADDR,
+            &mut [val],
+        )?;        
+        Ok(val & BME680_MEASURING_MSK != 0)
     }
 
     /// Retrieve the current sensor informations


### PR DESCRIPTION
It is the same issue as 
https://github.com/Zanduino/BME680/issues/14

Fixed by reading the status register until the MEASURING flag is not set before writing to the registers.
