### PR TITLE
Fix optional definition of FieldData

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,8 +302,7 @@ impl Clone for CalibData {
 
 /// Contains read sensors values  e.g. temperature, pressure, humidity etc.
 #[derive(Debug, Default, Copy)]
-#[cfg(feature = "serde")]
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct FieldData {
     /// Contains new_data, gasm_valid & heat_stab


### PR DESCRIPTION
The last PR, #47, only defines `FieldData` if the `serde` feature is set. My bad.

This fixes that. It only derives `Serialize` and `Deserialize` on `FieldData` if the `serde` feature is set, leaving `FieldData` in tact regardless. 